### PR TITLE
rename lambda argument shortcut from #arg to #it

### DIFF
--- a/lib/core-macros.mjs
+++ b/lib/core-macros.mjs
@@ -321,7 +321,7 @@ module.exports = (ast) -> do (
           current-arg-name = '__$arg$' + n
         body.forEachRecursive
           node -> do!
-            if (node.isPlaceholder() && (node.getSimpleValue() == current-id || (n == 1 && node.getSimpleValue() == '#arg')))
+            if (node.isPlaceholder() && (node.getSimpleValue() == current-id || (n == 1 && node.getSimpleValue() == '#it')))
               if (!process-next)
                 process-next = true;
                 args.push((ast.newTag current-arg-name).handleAsFunctionArgument())

--- a/test/meta-test.mjs
+++ b/test/meta-test.mjs
@@ -632,7 +632,7 @@ it 'Has lambda expressions'
   var f1 = #->()
   var f2 = #->
   var f3 = #->(#1 + #2)
-  var f4 = #->(#arg * 2)
+  var f4 = #->(#it * 2)
   (f1() == ()).should.equal true
   (f2() == ()).should.equal true
   f3(1, 2).should.equal 3


### PR DESCRIPTION
It's arguably easier to touch type and more similar to how groovy handles it.
