### PR TITLE
Support embedded source maps and definition of a srcmap root

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -2449,6 +2449,7 @@ function Meta() {
       if (typeof this.options.map !== 'undefined') {
         this.options.escodegen.sourceMap = this.options.source;
         this.options.escodegen.sourceMapWithCode = true;
+        this.options.escodegen.sourceMapRoot = this.options.mapRoot || null;
       }
     }
     this.options.fullMacroErrors =
@@ -5521,7 +5522,13 @@ function Meta() {
 
       if (generated.map && typeof options.map !== 'undefined') {
         try {
-          fs.writeFileSync(options.map, generated.map);
+          if (typeof options.output !== 'undefined' && options.map === '-') {
+            var datauri = '\n//# sourceMappingURL=data:application/json;base64,';
+            datauri += new Buffer(generated.map).toString('base64');
+            fs.appendFileSync(options.output, datauri);
+          } else {
+            fs.writeFileSync(options.map, generated.map);
+          }
         } catch (e) {
           this.root.error('Error writing map file: ', e.toString());
         }
@@ -5576,20 +5583,15 @@ Meta.prototype.setOptions = function (options) {
         case 'source':
         case 'output':
         case 'map':
+        case 'mapRoot':
           checkOption(optName, options[optName], 'string');
           break;
         case 'escodegen':
           checkOption(optName, options[optName], 'object');
           break;
         case 'sourceInMap':
-          checkOption(optName, options[optName], 'boolean');
-          break;
         case 'skipCore':
-          checkOption(optName, options[optName], 'boolean');
-          break;
         case 'fullMacroErrors':
-          checkOption(optName, options[optName], 'boolean');
-          break;
         case 'emitIdentifierStatements':
           checkOption(optName, options[optName], 'boolean');
           break;

--- a/lib/mjs.js
+++ b/lib/mjs.js
@@ -55,6 +55,11 @@ function run() {
           commandLineOptions.map = argv.shift();
         }
         break;
+      case '--maproot':
+        if (checkArgument(opt)) {
+          commandLineOptions.mapRoot = argv.shift();
+        }
+        break;
       case '-nm':
       case '-nomap':
       case '--nomap':
@@ -116,7 +121,8 @@ function run() {
       'Options (alternative aliases separated by commas, arguments enclosed in <>):',
       '  [-i, --input, -s, --source] <file> : input file',
       '           -o, -out, --output <file> : destination javascript file',
-      '          -m, -map, --mapfile <file> : map file',
+      '          -m, -map, --mapfile <file> : map file (use - to embed in output file)',
+      '                    --maproot <root> : define a root for source map references',
       '                -nm, -nomap, --nomap : do not generate map file',
       '             -fme, --fullMacroErrors : emit full errors during macro expansion',
       '    -eis, --emitIdentifierStatements : emit top level identifier statements (use only in editors)',


### PR DESCRIPTION
Added a new command line switch (`--maproot`) to define a root for the sourcemap files, this allows to use them on Firefox when loading from a local file (ie: `mjs --maproot file://`).

Also included an option (`--mapfile -`) to embed the generated source map as a comment in the output file. This works great because together with the inclusion of the original source code in the maps allows to have everything bundled with the file loaded by the browser.
