### PR TITLE
Support for regexp literals

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -5039,6 +5039,10 @@ function Meta() {
       this.addPrimitive('<val>', value);
       break;
     case 'object':
+      if (value instanceof RegExp) {
+        this.addPrimitive('<val>', value);
+        break;
+      }
       if (value !== null) {
         this.error('Unexpected object value');
       }
@@ -5240,6 +5244,62 @@ function Meta() {
       }
     };
 
+    var consumeRELiteral = function () {
+      var saveColumnNumber = me.currentColumnNumber;
+      var saveRemaining = remaining;
+      
+      var token = '';
+      consumeChar();
+      while (remaining !== null && remaining.length > 0) {
+        var current = remaining.charAt(0);
+        consumeChar();
+
+        if (current === '/') {
+          if (token === '') {
+            break;
+          }
+
+          // Consume regexp flags
+          var flags = '';
+          while (remaining !== null && remaining.length > 0) {
+            current = remaining.charAt(0);
+            if (!/[A-Za-z]/.test(current)) {
+              break;
+            }
+            consumeChar();
+            flags += current;
+          }
+
+          var rex;
+          try {
+            rex = new RegExp(token, flags);
+          } catch (e) {
+            me.error('Unable to parse regex: ' + e.message);
+          }
+
+          me.addValue(rex);
+          return true;
+        } else if (current === ' ') {
+          // Disambiguate with division by disallowing spaces (ie: 100 / 10 / 5)
+          break;
+        } else {
+          token += current;
+          if (current === '\\') {
+            if (remaining.length === 0) {
+              break;
+            }
+            token += remaining.charAt(0);
+            consumeChar();
+          }
+        }
+      }
+      
+      hasError = false;
+      me.currentColumnNumber = saveColumnNumber;
+      remaining = saveRemaining;
+      return false;
+    };
+
     this.currentColumnNumber = 0;
     var isInIndent = true;
     while (isInIndent) {
@@ -5323,6 +5383,9 @@ function Meta() {
       case '\'':
         consumeStringLiteral();
         break;
+      case '/':
+        if (consumeRELiteral())
+          break;
       default:
         var token;
         token = tryMatch(/^([-][\>]?)*[_$a-zA-Z\xA0-\uFFFF]([_$a-zA-Z0-9\xA0-\uFFFF]|([-][\>]?))*[\!\?]*/);

--- a/test/meta-test.mjs
+++ b/test/meta-test.mjs
@@ -737,3 +737,16 @@ it 'Has a proper \"@\" operator'
   ((obj.m4 'a') + (obj.m4 'b')).should.equal 3
   (obj.m5()['a'] + obj.m5()['b']).should.equal 3
 SKIPME
+
+it 'Can parse regexp'
+  var re = /bar/
+  re.test('foobarbaz').should.be.ok
+
+  /http:\/\//.test('http://google.com').should.be.ok
+  /foo/i.test('FOO').should.be.ok
+  /f([o])o/.test('foo').should.be.ok
+
+it 'Can parse forward slashes'
+  (10 / 5).should.equal 2
+  (100 / 10 / 2).should.equal 5
+


### PR DESCRIPTION
Incorporates regexp literals to the language with the exact same syntax they have on JavaScript.

The only inconvenience is the disambiguation with the division operator, since on metascript the following is equivalent:

```
func /foo/  ->  func(/foo/)
```

it gets trickier to detect what's a regexp literal and what's just an arithmetic operation with two division operators on the same line. The solution implemented has been to completely forbid spaces on regexp literals:

```
func /foo/  -> func(/foo/)
func / foo/ bar -> func / foo/ bar
```

In the future I would like to extend the regexp literal syntax to allow it to support multi line patterns ala [xregexp](http://xregexp.com/) by following the triple quotes for strings:

```
///
  foo       ; ident
  [a-z]+   ; class
  (?<num> \d+ )  ; capture with name
///m
```
