### PR TITLE
Support for fat-arrow `=>` using Function.bind

### DIFF
--- a/lib/core-macros.mjs
+++ b/lib/core-macros.mjs
@@ -329,6 +329,21 @@ module.exports = (ast) -> do (
     `(~` args) -> (~` body)
 
 
+; Fat arrow, binds `this` to the function's lexical context
+; Note: Implemented using the native Function.bind method, which is known to
+;       be slow for this use case. In the future we may want to refactor this
+;       macro to use a faster closure based approach.
+#keepmacro =>
+  binary
+  FUNCTION
+  expand: (lhs, rhs) ->
+    `
+      (
+        (~`lhs) -> 
+          ~`rhs
+      ).bind(this)
+
+
 null
 )
 

--- a/test/functional/fat-arrow-apply.mjs
+++ b/test/functional/fat-arrow-apply.mjs
@@ -1,0 +1,13 @@
+'''
+global
+global
+'''
+
+var obj1 = { id: 'obj1' }
+var obj2 = { id: 'obj2' }
+
+var id = 'global'
+var fn = () => this.id
+
+console.log(fn.apply(obj1, []))
+console.log(fn.call(obj2))

--- a/test/functional/fat-arrow-constructor.mjs
+++ b/test/functional/fat-arrow-constructor.mjs
@@ -1,0 +1,17 @@
+'''
+foo
+foo
+'''
+
+var O = () ->
+  this.foo = 'foo'
+  this.fn = () =>
+    this.foo
+  this
+
+var o = new O()
+
+console.log( o.fn() )
+
+var fn = o.fn
+console.log( fn() )

--- a/test/functional/fat-arrow-global.mjs
+++ b/test/functional/fat-arrow-global.mjs
@@ -1,0 +1,10 @@
+'''
+foo
+'''
+
+var foo = 'foo'
+
+var fn = () =>
+  this.foo
+
+console.log(fn())

--- a/test/functional/fat-arrow-target.mjs
+++ b/test/functional/fat-arrow-target.mjs
@@ -1,0 +1,13 @@
+'''
+global
+'''
+
+var id = 'global'
+var fn = () => this.id
+
+var obj1 = {
+  id: 'obj1'
+  fn: fn
+}
+
+console.log( obj1.fn() )


### PR DESCRIPTION
Not the fastest way to implement this functionality but it's very simple and the semantics wouldn't change when optimizing it in the future.
