### PR TITLE
Use a location manager to reduce creation of additional objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib/core-macros.js*
+lib/compiler/*.js*
 lib/regenerator-runtime.json
 lib/compiler/*.js*
 test/functional-test.js*

--- a/lib/compiler/location.mjs
+++ b/lib/compiler/location.mjs
@@ -1,0 +1,76 @@
+'''
+Tracks source code locations for the compiler.
+
+To avoid creating tons of small objects the information for source
+file, line number and column is encoded in a single number value using
+bitwise operators (so only 32 bits are used).
+The number stores in this order: an index to a source file, the line
+and the column. This allows for cheap operations when comparing locations.
+'''
+
+var
+  SOURCE_BITS = 6
+  LINE_BITS   = 16
+  COLUMN_BITS = 10
+  SOURCE_MASK = (1 << SOURCE_BITS) - 1
+  LINE_MASK   = (1 << LINE_BITS) - 1
+  COLUMN_MASK = (1 << COLUMN_BITS) - 1
+
+console.assert(SOURCE_BITS + LINE_BITS + COLUMN_BITS <= 32, 'Bits should not add up over 32');
+
+var LocationManager = () ->
+  this.sources = ['<unknown>']
+  this  ; Force to return the instance
+
+LocationManager.prototype.DEFAULT = 0
+
+LocationManager.prototype.add-source = (source) ->
+  var src-idx = this.sources.indexOf(source)
+  if (src-idx == -1)
+    src-idx = this.sources.length
+    this.sources.push(source)
+
+  src-idx
+
+LocationManager.prototype.make-loc = (source, line, column) ->
+  var src-idx = this.add-source(source)
+
+  src-idx &= SOURCE_MASK
+  line &= LINE_MASK
+  column &= COLUMN_MASK
+
+  ;console.log(source, src-idx, line, column, this.sources)
+
+  (src-idx << (LINE_BITS + COLUMN_BITS)) | (line << COLUMN_BITS) | column
+
+LocationManager.prototype.get-source = (loc) ->
+  var src-idx = (loc >> (LINE_BITS + COLUMN_BITS)) & SOURCE_MASK
+  this.sources[src-idx]
+
+LocationManager.prototype.get-line = (loc) ->
+  (loc >> COLUMN_BITS) & LINE_MASK
+
+LocationManager.prototype.get-column = (loc) ->
+  loc & COLUMN_MASK
+
+LocationManager.prototype.as-object = (start, end) ->
+  {
+    source: this.get-source start
+    start: {
+      line: this.get-line start
+      column: this.get-column start
+    }
+    end: {
+      line: this.get-line end
+      column: this.get-column end
+    }
+  } 
+
+LocationManager.prototype.from-object = (obj) ->
+  [
+    this.make-loc(obj.source, obj.start.line, obj.start.column)
+    this.make-loc(obj.source, obj.end.line, obj.end.column)
+  ]
+
+
+#external(exports).LocationManager = LocationManager

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -17,6 +17,8 @@ function Meta() {
   var path = require('path');
   var escodegen = require('escodegen');
 
+  // Project modules
+  var LocationManager = require('./compiler/location').LocationManager;
   var constants = require('./compiler/constants');
 
 
@@ -2515,6 +2517,7 @@ function Meta() {
     }
 
     this.reader = r;
+    this.locManager = new LocationManager();
     this.errors = [];
     this.root = null;
 
@@ -2568,23 +2571,28 @@ function Meta() {
         }
       }
 
+      this.locStart = compiler.locManager.DEFAULT;
+      this.locEnd = compiler.locManager.DEFAULT;
+      this.locOriginStart = compiler.locManager.DEFAULT;
+      this.locOriginEnd = compiler.locManager.DEFAULT;
+
       if (typeof parent === 'undefined') {
         // No parent provided: assume it is the current block
         // (this works when the constructor is called by the parser).
-        this.loc = parser.currentLocation();
+        var startEnd = parser.currentLocation();
+        this.locStart = startEnd[0];
+        this.locEnd = startEnd[1];
         if (parser.currentBlock !== null) {
           parser.currentBlock.push(this);
         }
         this.parent = parser.currentBlock;
       } else {
         // Use the provided parent, if any.
-        this.loc = parser.unknownLocation();
         if (parent !== null) {
           parent.push(this);
         }
         this.parent = parent;
       }
-      this.origin = null;
 
       if (this.isBlock()) {
         this.block = {
@@ -2653,6 +2661,39 @@ function Meta() {
     Expr.prototype.compiler = compiler;
     Expr.prototype.parser = parser;
 
+    // Backwards compatibility for loc information
+    Object.defineProperty(Expr.prototype, 'loc', {
+      get: function () {
+        return this.compiler.locManager.asObject(this.locStart, this.locEnd);
+      },
+      set: function (loc) {
+        console.warn('[Deprecated: Expr.loc] Use .locStart and .locEnd');
+        var startEnd = this.compiler.locManager.fromObject(loc);
+        this.locStart = startEnd[0];
+        this.locEnd = startEnd[1];
+      }
+    });
+    Object.defineProperty(Expr.prototype, 'origin', {
+      get: function () {
+        console.warn('[Deprecated: Expr.origin] Use .locOriginStart and .locOriginEnd');
+        if (this.locOriginStart === this.compiler.locManager.DEFAULT) {
+          return null;
+        }
+        return this.compiler.locManager.asObject(this.locOriginStart, this.locOriginEnd);
+      },
+      set: function (loc) {
+        console.warn('[Deprecated: Expr.origin] Use .locOriginStart and .locOriginEnd');
+        if (loc === null) {
+          this.locOriginStart = this.compiler.locManager.DEFAULT;
+          this.locOriginEnd = this.compiler.locManager.DEFAULT;
+        } else {
+          var startEnd = this.compiler.locManager.fromObject(loc);
+          this.locOriginStart = startEnd[0];
+          this.locOriginEnd = startEnd[1];
+        }
+      }
+    });
+
     Expr.prototype.isBlock = function () {
       if (this.sym === null) return false;
       return this.parser.isBlock(this.sym.id);
@@ -2671,7 +2712,7 @@ function Meta() {
         id: this.sym.id,
         kind: this.sym.kind,
         val: this.val,
-        loc: this.copyBestLoc(),
+        loc: this.bestLoc(),
         args: []
       };
       for (var i = 0; i < this.argCount(); i++) {
@@ -2721,8 +2762,11 @@ function Meta() {
           return this.undefinedExpression();
       }
       var result = new Expr(sym, json.val, [], parent);
-      result.loc = this.copyLoc();
-      result.origin = json.loc;
+      result.locStart = this.locStart;
+      result.locEnd = this.locEnd;
+      var locmgr = this.compiler.locManager;
+      result.locOriginStart = locmgr.makeLoc(json.loc.source, json.loc.start.line, json.loc.start.column)
+      result.locOriginEnd = locmgr.makeLoc(json.loc.source, json.loc.end.line, json.loc.end.column)
       for (var i = 0; i < json.args.length; i++) {
         this.fromJsonObject(json.args[i], resolutionRoot, locationRoot, result);
       }
@@ -2730,46 +2774,27 @@ function Meta() {
     };
     Expr.prototype.fromJsonString = function (jsonString, resolutionRoot, locationRoot, parent) {
       var json = JSON.parse(jsonString);
-      var  result = this.fromJsonObject(json, resolutionRoot, locationRoot, parent);
+      var result = this.fromJsonObject(json, resolutionRoot, locationRoot, parent);
       return result;
     };
 
-    Expr.prototype.copyLoc = function () {
-      if (this.loc !== null) {
-        return {
-          source: this.loc.source,
-          start: {line: this.loc.start.line, column: this.loc.start.column},
-          end: {line: this.loc.end.line, column: this.loc.end.column}
-        };
-      } else {
-        return null;
-      }
-    };
-    Expr.prototype.copyOrigin = function () {
-      if (this.origin !== null) {
-        return {
-          source: this.origin.source,
-          start: {line: this.origin.start.line, column: this.origin.start.column},
-          end: {line: this.origin.end.line, column: this.origin.end.column}
-        };
-      } else {
-        return null;
-      }
-    };
     Expr.prototype.bestLoc = function () {
-      return this.origin !== null ? this.origin : this.loc;
-    };
-    Expr.prototype.copyBestLoc = function () {
-      return this.origin !== null ? this.copyOrigin() : this.copyLoc();
+      var locmgr = this.compiler.locManager;
+      if (this.locOriginStart !== locmgr.DEFAULT) {
+        return locmgr.asObject(this.locOriginStart, this.locOriginEnd);
+      } else {
+        return locmgr.asObject(this.locStart, this.locEnd);
+      }
     };
 
     Expr.prototype.undefinedExpression = function () {
+      var locmgr = this.compiler.locManager;
       var json = {
         id: meta.tagSymbol.id,
         kind: 'tag',
         val: 'undefined',
-        loc: this.copyLoc(),
-        origin: this.copyOrigin(),
+        loc: locmgr.asObject(this.locStart, this.locEnd),
+        origin: locmgr.asObject(this.locOriginStart, this.locOriginEnd),
         args: []
       };
       return this.fromJsonObject(json, this, this, null);
@@ -3332,30 +3357,14 @@ function Meta() {
     };
 
     Expr.prototype.takeLocationFrom = function (other) {
-      this.loc = other.loc === null ? null : {
-        source: other.loc.source,
-        start: {line: other.loc.start.line, column: other.loc.start.column},
-        end: {line: other.loc.end.line, column: other.loc.end.column}
-      };
-      this.origin = other.origin === null ? null : {
-        source: other.origin.source,
-        start: {line: other.origin.start.line, column: other.origin.start.column},
-        end: {line: other.origin.end.line, column: other.origin.end.column}
-      };
+      this.locStart = other.locStart;
+      this.locEnd = other.locEnd;
+      this.locOriginStart = other.locOriginStart;
+      this.locOriginEnd = other.locOriginEnd;
     };
     Expr.prototype.mergeLoc = function (otherExpr) {
-      if (this.loc.start.line >= otherExpr.loc.start.line) {
-        this.loc.start.line = otherExpr.loc.start.line;
-        if (this.loc.start.column >= otherExpr.loc.start.column) {
-          this.loc.start.column = otherExpr.loc.start.column;
-        }
-      }
-      if (this.loc.end.line <= otherExpr.loc.end.line) {
-        this.loc.end.line = otherExpr.loc.end.line;
-        if (this.loc.end.column <= otherExpr.loc.end.column) {
-          this.loc.end.column = otherExpr.loc.end.column;
-        }
-      }
+      this.locStart = Math.min(this.locStart, otherExpr.locStart);
+      this.locEnd = Math.max(this.locEnd, otherExpr.locEnd);
     };
     Expr.prototype.newAtThisLocation = function (sym) {
       if (typeof sym === 'string') {
@@ -3580,11 +3589,13 @@ function Meta() {
     };
 
     Expr.prototype.createError = function (message, nestedErrors) {
+      var locmgr = this.compiler.locManager;
+      var hasOrigin = this.locOriginStart !== locmgr.DEFAULT;
       return new meta.Error(
-        message, this.loc.start.line, this.loc.start.column,
-        this.origin !== null ? this.origin.start.line : null,
-        this.origin !== null ? this.origin.start.column : null,
-        this.origin !== null ? this.origin.source : null,
+        message, locmgr.getLine(this.locStart), locmgr.getColumn(this.locStart),
+        hasOrigin ? locmgr.getLine(this.locOriginStart) : null,
+        hasOrigin !== null ? locmgr.getColumn(this.locOriginStart) : null,
+        hasOrigin !== null ? locmgr.getSource(this.locOriginStart) : null,
         nestedErrors);
     };
 
@@ -4015,8 +4026,11 @@ function Meta() {
     };
 
     Expr.prototype.toString = function () {
+      var locmgr = this.compiler.locManager;
       return util.format('sym "%s", val "%s", loc %d:%d [%s]',
-                         this.sym.id, this.val, this.loc.start.line, this.loc.start.column, this.loc.source);
+                         this.sym.id, this.val,
+                         locmgr.getLine(this.locStart), locmgr.getColumn(this.locStart),
+                         locmgr.getSource(this.locStart));
     };
 
     Expr.prototype.argCount = function () {
@@ -4932,9 +4946,10 @@ function Meta() {
     };
 
     Expr.prototype.clearLocation = function () {
-      this.loc = null;
-      for (var i = 0; i < this.argCount(); i++) {
-        this.argAt(i).clearLocation();
+      var locmgr = this.compiler.locManager;
+      this.startLoc = this.endLoc = locmgr.DEFAULT;
+      for (var i = 0; i < this.count; i++) {
+        this.at(i).clearLocation();
       }
     };
     Expr.prototype.normalizeLocation = function () {
@@ -4944,14 +4959,19 @@ function Meta() {
       }
     };
     Expr.prototype.checkLocation = function (line, column, startsBefore, endsAfter) {
-      var startsResult = (startsBefore !== undefined) ? (
-        startsBefore ? ((this.loc.start.line <= line) && (this.loc.start.column <= column)) :
-          ((this.loc.start.line > line) && (this.loc.start.column > column))
+      var loc, startsResult, endResult;
+      var locmgr = this.compiler.locManager;
+
+      loc = locmgr.makeLoc(locmgr.getSource(this.locStart), line, column);
+      startsResult = (startsBefore !== undefined) ? (
+        startsBefore ? (this.locStart <= loc) : (this.locStart > loc)
       ) : true;
-      var endResult = (endsAfter !== undefined) ? (
-        endsAfter ? ((this.loc.end.line >= line) && (this.loc.end.column >= column)) :
-          ((this.loc.end.line < line) && (this.loc.end.column < column))
+
+      loc = locmgr.makeLoc(locmgr.getSource(this.locEnd), line, column);
+      endResult = (endsAfter !== undefined) ? (
+        endsAfter ? (this.locEnd >= loc) : (this.locEnd < loc)
       ) : true;
+      
       return startsResult && endResult;
     };
     Expr.prototype.includesLocation = function (line, column) {
@@ -4960,8 +4980,8 @@ function Meta() {
     Expr.prototype.findLocation = function (line, column, startsBefore, endsAfter, firstResult) {
       if (typeof firstResult === 'undefined') firstResult = true;
       var lastFoundChild = null;
-      for (var i = 0; i < this.argCount(); i++) {
-        var childResult = this.argAt(i).findLocation(line, column, startsBefore, endsAfter);
+      for (var i = 0; i < this.count; i++) {
+        var childResult = this.at(i).findLocation(line, column, startsBefore, endsAfter);
         if (childResult !== null) {
           if (firstResult) {
             return childResult;
@@ -5136,38 +5156,15 @@ function Meta() {
     if (line === 0) line = 1;
     if (typeof c1 === 'undefined') { c1 = this.tokenInitialColumnNumber; }
     if (typeof c2 === 'undefined') { c2 = this.currentColumnNumber; }
-    return {
-      source: this.source ? this.source : null,
-      start: {line: line, column: c1},
-      end: {line: line, column: c2}
-    };
-  };
-  meta.Parser.prototype.setLocationEnd = function (location, column) {
-    if (location) {
-      if (typeof column === 'undefined') { column = this.currentColumnNumber; }
-      location.end.line = this.currentLineNumber;
-      location.end.column = column;
-    }
-  };
-  meta.Parser.prototype.enclosingLocation = function (start, end) {
-    if (start && end) {
-      return {
-        source: start.source,
-        start: start.start,
-        end: end.end
-      };
-    } else {
-      return null;
-    }
-  };
-  meta.Parser.prototype.unknownLocation = function () {
-    return {
-      source: 'unknown',
-      start: {line: 1, column: 0},
-      end: {line: 1, column: 0}
-    };
-  };
 
+    return [
+      this.makeLoc(line, c1),
+      this.makeLoc(line, c2)
+    ];
+  };
+  meta.Parser.prototype.makeLoc = function (line, column) {
+    return this.compiler.locManager.makeLoc(this.source || '<unknown>', line, column);
+  };
   meta.Parser.prototype.dumpBlockStack = function () {
     var result = '( ';
     var cur = this.currentBlock;
@@ -5198,10 +5195,10 @@ function Meta() {
     if (typeof isIndented === 'undefined') isInIndent = false;
     var result = this.currentBlock;
     if (result !== null) {
-      this.setLocationEnd(result.loc);
       if (isIndented) {
-        result.loc.end.line = this.indentedBlockLastLine;
-        result.loc.end.column = this.indentedBlockLastColumn;
+        result.locEnd = this.makeLoc(this.indentedBlockLastLine, this.indentedBlockLastColumn);
+      } else {
+        result.locEnd = this.makeLoc(this.currentLineNumber, this.currentColumnNumber);
       }
       result = result.parent;
       if (result !== null) {


### PR DESCRIPTION
Two big changes in this pull :)

The first one is to reduce the object allocation pressure on the javascript engine by avoiding the use of objects for the location tracking information. It uses a helper `LocationManager` to encode the information into plain numbers, currently with these limits: 65K lines, 1K columns, 64 files. I don't expect this change to make any noticeable difference on the compilation speed but it should help a bit with memory usage.

<del>The second is a product of `LocationManager` being implemented in metascript :squirrel:, this means that the compiler needs to start being _self hosted_. To solve the bootstrapping problem I've included a new dev dependency in the package for metascript 0.0.35, and then use it to compile any .mjs files in the compiler to bootstrap it. I think this should work for some time, obviously if the language evolves substantially we'll want to a more modern bootstrapping compiler but that's a thought for another day :)</del> (now on its own PR https://github.com/massimiliano-mantione/metascript/pull/49) 
