### PR TITLE
string literals refactor

### DIFF
--- a/lib/core-macros.mjs
+++ b/lib/core-macros.mjs
@@ -330,9 +330,6 @@ module.exports = (ast) -> do (
 
 
 ; Fat arrow, binds `this` to the function's lexical context
-; Note: Implemented using the native Function.bind method, which is known to
-;       be slow for this use case. In the future we may want to refactor this
-;       macro to use a faster closure based approach.
 #keepmacro =>
   arity: binary
   precedence: FUNCTION

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -2548,7 +2548,6 @@ function Meta() {
     this.currentBlock = this.root;
 
     this.multilineStringIsLiterate = false;
-    this.multilineStringKeepsNewlines = false;
     this.multilineStringContents = null;
     this.multilineStringTerminator = null;
 
@@ -5270,6 +5269,9 @@ function Meta() {
     return this.currentBlock;
   };
   meta.Parser.prototype.closeAllBlocks = function () {
+    if (null !== this.multilineStringContents) {
+      this.error('Unterminated multiline string');
+    }
     while (this.currentBlock.parent !== null) {
       if (this.currentBlock.isEmpty()) {
         this.removeCurrentBlock();
@@ -5280,7 +5282,7 @@ function Meta() {
   };
 
   meta.Parser.prototype.addPrimitive = function (primitive, value) {
-    this.Expr(primitive, value);
+    return this.Expr(primitive, value);
   };
   meta.Parser.prototype.addValue = function (value) {
     switch (typeof value) {
@@ -5288,18 +5290,15 @@ function Meta() {
     case 'boolean':
     case 'number':
     case 'string':
-      this.addPrimitive('<val>', value);
-      break;
+      return this.addPrimitive('<val>', value);
     case 'object':
       if (value !== null) {
         this.error('Unexpected object value');
       }
-      this.addPrimitive('<val>', null);
-      break;
+      return this.addPrimitive('<val>', null);
     default:
       this.error('Unexpected value type ' + typeof value);
-      this.addPrimitive('<val>', null);
-      break;
+      return this.addPrimitive('<val>', null);
     }
   };
   meta.Parser.prototype.addOperator = function (value) {
@@ -5351,27 +5350,6 @@ function Meta() {
       this.addNewLine();
     }
 
-    if (this.multilineStringContents !== null) {
-      if (line === this.multilineStringTerminator) {
-        if (!this.multilineStringIsLiterate) {
-          this.addValue(this.multilineStringContents);
-        } else if (this.currentBlock.__doc__) {
-          this.currentBlock.__doc__ += '\n' + this.multilineStringContents;
-        } else {
-          this.currentBlock.__doc__ = this.multilineStringContents;
-        }
-        this.multilineStringIsLiterate = false;
-        this.multilineStringContents = null;
-        this.multilineStringTerminator = null;
-      } else {
-        this.multilineStringContents += line;
-        if (this.multilineStringKeepsNewlines) {
-          this.multilineStringContents += '\n';
-        }
-      }
-      return;
-    }
-
     var remaining = line;
     var me = this;
     var hasError = false;
@@ -5397,124 +5375,215 @@ function Meta() {
       }
       me.currentColumnNumber++;
     };
+
     var consumeStringLiteral = function () {
       hasError = false;
-      var delimiter = remaining.charAt(0);
-      var multilineDelimiter = delimiter + delimiter + delimiter;
-      if (remaining.indexOf(multilineDelimiter) === 0) {
-        if (me.currentColumnNumber === 0) {
-          me.multilineStringIsLiterate = true;
-        }
-        remaining = remaining.substring(3);
-        me.multilineStringContents = '';
-        me.multilineStringKeepsNewlines = (delimiter === '\'');
-        me.currentColumnNumber += 3;
-        if (remaining === null || remaining.length === 0) {
-          me.multilineStringTerminator = multilineDelimiter;
-        } else {
-          me.multilineStringTerminator = remaining;
-        }
-        remaining = null;
+      var delimiter;
+
+      if (null !== me.multilineStringContents) {
+        delimiter = me.multilineStringTerminator.charAt(0);
       } else {
-        var token = '';
-        consumeChar();
-        while (remaining !== null && remaining.length > 0) {
-          var current = remaining.charAt(0);
-          if (current === delimiter) {
-            me.addValue(token);
+        delimiter = remaining.charAt(0);
+
+        // Check if we are at a multiline delimiter
+        var multilineDelimiter = delimiter;
+        for (var i = 1; remaining.charAt(i) === delimiter; i++) {
+          multilineDelimiter += delimiter;
+        }
+        if (multilineDelimiter.length >= 3) {
+          me.multilineStringTerminator = multilineDelimiter;
+          me.multilineStringContents = '';
+          me.multilineStringIsLiterate = (me.currentColumnNumber === 0);
+          remaining = remaining.substring(multilineDelimiter.length);
+          me.currentColumnNumber += multilineDelimiter.length;
+        } else {
+          consumeChar();
+        }
+      }
+
+      var token = '';
+      while (remaining !== null && remaining.length > 0) {
+        var current = remaining.charAt(0);
+        if (current === delimiter) {
+          if (null === me.multilineStringContents) {
+            me.addValue(token).set('quote', delimiter);
             consumeChar();
             return;
-          } else if (current === '\\') {
-            consumeChar();
-            var quoted = remaining.charAt(0);
-            consumeChar();
-            switch (quoted) {
-            case 'b':
-              token += '\b';
-              break;
-            case 'f':
-              token += '\f';
-              break;
-            case 'n':
-              token += '\n';
-              break;
-            case 'r':
-              token += '\r';
-              break;
-            case 't':
-              token += '\t';
-              break;
-            case 'v':
-              token += '\v';
-              break;
-            case '\'':
-              token += '\'';
-              break;
-            case '\"':
-              token += '\"';
-              break;
-            case '\\':
-              token += '\\';
-              break;
-            case 'x':
-              var hexLatin1 = remaining.substring(0, 2);
-              remaining = remaining.substring(2);
-              me.currentColumnNumber += 2;
-              if (/^[0-9a-fA-F][0-9a-fA-F]/.test(hexLatin1)) {
-                token += String.fromCharCode(parseInt(hexLatin1, 16));
-              } else {
-                me.error('Unrecognized hex escape');
-                token += '?';
-              }
-              break;
-            case 'u':
-              var hexUnicode = remaining.substring(0, 4);
-              remaining = remaining.substring(4);
-              me.currentColumnNumber += 4;
-              if (/^[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]/.test(hexUnicode)) {
-                token += String.fromCharCode(parseInt(hexUnicode, 16));
-              } else {
-                me.error('Unrecognized unicode escape');
-                token += '?';
-              }
-              break;
-            case '0':
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-              var hexOctal = quoted + remaining.substring(0, 2);
-              remaining = remaining.substring(2);
-              me.currentColumnNumber += 2;
-              if (/^[0-7][0-7][0-7]/.test(hexOctal)) {
-                token += String.fromCharCode(parseInt(hexOctal, 8));
-              } else {
-                me.error('Unrecognized octal escape');
-                token += '?';
-              }
-              break;
-            default:
-              token += quoted;
-              break;
-            }
-          } else {
-            token += current;
-            consumeChar();
           }
+
+          // Have we found the end of a multiline string?
+          if (0 === remaining.indexOf(me.multilineStringTerminator)) {
+            token = me.multilineStringContents + token;
+
+            if (delimiter === '\'') {
+              // Single quoted are trimmed up to and including the first new line
+              token = token.replace(/^[ \t]*\n?/, '').replace(/\n?[ \t]*$/, '');
+            } else {
+              // Double quoted are just trimmed, folding already happens while parsing
+              token = token.replace(/^[ ]/, '').replace(/[ ]$/, '');
+            }
+
+            if (me.multilineStringIsLiterate) {
+              if (me.currentBlock === me.root && me.root.isEmpty()) {
+                me.root.set('doc', token);
+              }
+            } else {
+              me.addValue(token).set('quote', me.multilineStringTerminator);
+            }
+
+            remaining = remaining.substring(me.multilineStringTerminator.length);
+            me.currentColumnNumber += me.multilineStringTerminator.length;
+
+            me.multilineStringContents = null;
+            return;
+          }
+
+          token += delimiter;
+          consumeChar();
+        } else if (current === ' ' || current === '\t') {
+
+          // Trim double quotes multiline
+          if (null !== me.multilineStringContents && delimiter === '"') {
+            if (token === '') {
+              consumeChar();
+              continue;
+            } else if (/^\s+$/.test(remaining)) {
+              me.currentColumnNumber += remaining.length;
+              remaining = '';
+              continue
+            }
+          }
+
+          consumeChar();
+          token += current;
+
+        } else if (current === '\\') {
+          consumeChar();
+
+          // Single quotes do not interpret escape codes
+          if (delimiter === '\'') {
+            token += current;
+            continue;
+          }
+
+          var quoted = remaining.charAt(0);
+          consumeChar();
+          switch (quoted) {
+          case 'b':
+            token += '\b';
+            break;
+          case 'f':
+            token += '\f';
+            break;
+          case 'n':
+            token += '\n';
+            break;
+          case 'r':
+            token += '\r';
+            break;
+          case 't':
+            token += '\t';
+            break;
+          case 'v':
+            token += '\v';
+            break;
+          case '\'':
+            token += '\'';
+            break;
+          case '\"':
+            token += '\"';
+            break;
+          case '\\':
+            token += '\\';
+            break;
+          case 'x':
+            var hexLatin1 = remaining.substring(0, 2);
+            remaining = remaining.substring(2);
+            me.currentColumnNumber += 2;
+            if (/^[0-9a-fA-F][0-9a-fA-F]/.test(hexLatin1)) {
+              token += String.fromCharCode(parseInt(hexLatin1, 16));
+            } else {
+              me.error('Unrecognized hex escape');
+              token += '?';
+            }
+            break;
+          case 'u':
+            var hexUnicode = remaining.substring(0, 4);
+            remaining = remaining.substring(4);
+            me.currentColumnNumber += 4;
+            if (/^[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]/.test(hexUnicode)) {
+              token += String.fromCharCode(parseInt(hexUnicode, 16));
+            } else {
+              me.error('Unrecognized unicode escape');
+              token += '?';
+            }
+            break;
+          case '0':
+          case '1':
+          case '2':
+          case '3':
+          case '4':
+          case '4':
+          case '5':
+          case '6':
+          case '7':
+            var hexOctal = quoted + remaining.substring(0, 2);
+            remaining = remaining.substring(2);
+            me.currentColumnNumber += 2;
+            if (/^[0-7][0-7][0-7]/.test(hexOctal)) {
+              token += String.fromCharCode(parseInt(hexOctal, 8));
+            } else {
+              me.error('Unrecognized octal escape');
+              token += '?';
+            }
+            break;
+          default:
+            token += quoted;
+            break;
+          }
+
+        } else {
+          token += current;
+          consumeChar();
         }
+      }
+
+      if (null === me.multilineStringContents) {
         me.error('Unterminated string literal');
         remaining = null;
+      } else {
+        me.multilineStringContents += token;
       }
     };
 
     this.currentColumnNumber = 0;
 
+    var applyIndentation = true;
     var isInIndent = true;
     var indentToken = '';
+
+    if (null !== this.multilineStringContents) {
+      this.multilineStringContents += this.multilineStringTerminator.charAt(0) === '"' ? ' ' : '\n';
+      consumeStringLiteral();
+      if (null !== this.multilineStringContents) {
+        return;
+      }
+      applyIndentation = false;
+      isInIndent = false;
+    } else {
+      // Empty or pure comment lines do not affect indentation blocks.
+      if (remaining.length === 0 || remaining.charAt(0) === ';') {
+        applyIndentation = false;
+      }
+
+      // Ignore multiline strings starting at column 0
+      // (they can be used for literate programming).
+      if (this.currentColumnNumber === 0 &&
+          (remaining.indexOf('"""') === 0 || remaining.indexOf('\'\'\'') === 0)) {
+        applyIndentation = false;
+      }
+    }
+
     while (isInIndent) {
       var current = remaining.charAt(0);
       if (current === ' ') {
@@ -5531,20 +5600,6 @@ function Meta() {
       } else {
         isInIndent = false;
       }
-    }
-
-    var applyIndentation = true;
-
-    // Empty or pure comment lines do not affect indentation blocks.
-    if (remaining.length === 0 || remaining.charAt(0) === ';') {
-      applyIndentation = false;
-    }
-
-    // Ignore multiline strings starting at column 0
-    // (they can be used for literate programming).
-    if (this.currentColumnNumber === 0 &&
-        (remaining.indexOf('"""') === 0 || remaining.indexOf('\'\'\'') === 0)) {
-      applyIndentation = false;
     }
 
     // Handle block structure

--- a/test/functional-test.mjs
+++ b/test/functional-test.mjs
@@ -27,8 +27,8 @@ var compileAndAssert = (fname) ->
 
   ; Extract options from modeline
   if (code.substring(0, 6) == '; mjs:') do
-    var line = code.substr(6, code.indexOf '\n')
-    var modearg = new RegExp('\\s*([\\w\\d]+)(\\s*=\\s*([\\w\\d]+))?\\s*,?', 'g')
+    var line = code.substr(6, code.indexOf "\n")
+    var modearg = new RegExp('\s*([\w\d]+)(\s*=\s*([\w\d]+))?\s*,?', 'g')
     line.replace
       modearg
       (m0, m1, m2, m3) ->
@@ -50,10 +50,10 @@ var compileAndAssert = (fname) ->
 
   var ast = compiler.produceAst()
   if compiler.errors.length > 0 do
-    throw {name: 'CompilerError', message: compiler.errors.join('\n')}
+    throw {name: 'CompilerError', message: compiler.errors.join("\n")}
   
-  var expected = compiler.root.__doc__
-  expected.should.be.type('string')
+  var expected = compiler.root.get('doc')
+  console.assert(typeof expected == 'string', 'Testcase does not have a docblock')
   expected = expected.trim()
 
   var result = compiler.generate ast
@@ -62,14 +62,14 @@ var compileAndAssert = (fname) ->
 
   try do
     vm.runInThisContext
-      '(function (console) {' + result.code + '\n})(mockedConsole)'
+      "(function (console) {" + result.code + "\n})(mockedConsole)"
       fname
 
-    expected.should.equal( mocked-console.output.join('\n') )
+    expected.should.equal( mocked-console.output.join("\n") )
   catch (var e) do
     if process.env.VERBOSE do
       console.log('')
-      console.log(fname + '\n' + (new Array(fname.length)).join('=') + '=\n')
+      console.log(fname + "\n" + (new Array(fname.length)).join('=') + "=\n")
       console.log(compiler.root.printAst())
       console.log('')
       console.log(result.code)

--- a/test/functional/string-multiline-double.mjs
+++ b/test/functional/string-multiline-double.mjs
@@ -1,0 +1,33 @@
+'''
+<this text will be trimmed>
+Length: 2
+multiline inside an array
+another one with lines folded
+a multiline inside a function
+'''
+
+var a = """
+  this text will be trimmed  
+"""
+console.log('<' + a + '>')
+
+var b = [
+  """
+    multiline inside an array
+  """
+  """"
+    another one
+    with lines folded
+  """"
+]
+
+console.log('Length: ' + b.length)
+console.log(b[0])
+console.log(b[1])
+
+var fn = () ->
+  """
+  a multiline inside a function
+  """
+
+console.log(fn())

--- a/test/functional/string-multiline-single.mjs
+++ b/test/functional/string-multiline-single.mjs
@@ -1,0 +1,34 @@
+'''
+<  this text will not be trimmed but will have no new lines  >
+Length: 2
+    multiline inside an array
+    another one
+    with two lines
+  a multiline inside a function
+'''
+
+var a = '''
+  this text will not be trimmed but will have no new lines  
+'''
+console.log('<' + a + '>')
+
+var b = [
+  '''
+    multiline inside an array
+  '''
+  ''''
+    another one
+    with two lines
+  ''''
+]
+
+console.log('Length: ' + b.length)
+console.log(b[0])
+console.log(b[1])
+
+var fn = () ->
+  '''
+  a multiline inside a function
+  '''
+
+console.log(fn())

--- a/test/meta-test.mjs
+++ b/test/meta-test.mjs
@@ -742,7 +742,7 @@ it 'Has a working pre-expand'
   r.should.equal 'ok'
 
 
-'''SKIPME
+'''
 it 'Has a proper \"@\" operator'
   var obj = {
     a: 1
@@ -759,4 +759,4 @@ it 'Has a proper \"@\" operator'
   obj.m3('a', 'aa').should.equal 42
   ((obj.m4 'a') + (obj.m4 'b')).should.equal 3
   (obj.m5()['a'] + obj.m5()['b']).should.equal 3
-SKIPME
+'''

--- a/test/test.js
+++ b/test/test.js
@@ -98,19 +98,19 @@ describe('Meta.Compiler', function () {
       ]), '(b (l id:"print" val:"\n\t" val:"xy\uaBcDz" val:""))');
 
       compareArrayToTokenDump(parseArray([
-        'print """END\n1\n2\n3\nEND\nok'
-      ]), '(b (l id:"print" val:"123") (l id:"ok"))');
+        'print """\n 1 \n 2   \n 3 \n"""\nok'
+      ]), '(b (l id:"print" val:"1 2 3") (l id:"ok"))');
 
       compareArrayToTokenDump(parseArray([
-        'print """\n1\n2\n3\n"""\nok'
-      ]), '(b (l id:"print" val:"123") (l id:"ok"))');
-
-      compareArrayToTokenDump(parseArray([
-        'print \'\'\'END\n1\n2\n3\nEND\nok'
-      ]), '(b (l id:"print" val:"1\n2\n3\n") (l id:"ok"))');
+        'print """\n1  2  3   \n"""\nok'
+      ]), '(b (l id:"print" val:"1  2  3") (l id:"ok"))');
 
       compareArrayToTokenDump(parseArray([
         'print \'\'\'\n1\n2\n3\n\'\'\'\nok'
+      ]), '(b (l id:"print" val:"1\n2\n3") (l id:"ok"))');
+
+      compareArrayToTokenDump(parseArray([
+        'print \'\'\'\n1\n2\n3\n\n\'\'\'\nok'
       ]), '(b (l id:"print" val:"1\n2\n3\n") (l id:"ok"))');
     });
 
@@ -213,9 +213,9 @@ describe('Meta.Compiler', function () {
         '1\n2\n3',
         '"""',
         '    l3a',
-        '"""END',
+        '"""""',
         '1\n2\n3',
-        'END',
+        '"""""',
         '    l3b',
         'l1b'
       ]), '(b (l id:"l1a" (b (l id:"l2a" (b (l id:"l3a") ' +


### PR DESCRIPTION
# Overview
- `'` strings are verbatim, multiline get trimmed until the first newline
- `"` strings support escaping, multiline get trimmed and folded
- Multiline strings are started using 3 o more quotes and end when the same number of quotes are found
- Literate multistrings are still supported, when it appears as the first expression in a file it's stored in the _doc_ annotation of the root block.
- All strings are annotated with the name _quote_ and the delimiter used as value (might be helpful for macros)
# Explanation

The reasoning for making the single quoted strings verbatim is to enable macros for _embedded languages_, like we discussed on https://github.com/massimiliano-mantione/metascript/pull/22

The change of behaviour for multiline strings from a _perlish_ heredoc syntax (EOT at the start of a line) for a more pythonish approach, is mainly driven to allow these strings without breaking the indentation layout of the file. If the proposed change of matching the same amount of quotes to detect the end is not considered valid, perhaps I could try to introduce again the EOT symbol handling but lifting the requirement for it to be at the start of the line.
