### PR TITLE
generate verbatim javascript code

### DIFF
--- a/lib/core-macros.mjs
+++ b/lib/core-macros.mjs
@@ -349,6 +349,20 @@ module.exports = (ast) -> do (
     result.resolveVirtual()
     result
 
+#keepmacro js
+'''
+  Same as eval but for literal values allows to directly embed it in the
+  generated javascript code.
+  
+  Usage: js'bar ? 1 : -1'
+'''
+  unary
+  HIGH
+  expand: (expr) ->
+    var code = ` (#external eval)( ~`(expr) )
+    if (expr.value?())
+      code.set('js', expr.get-value())
+    code
+
 null
 )
-

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -487,13 +487,17 @@ function Meta() {
       right: right
     };
   };
-  meta.codegenCall = function (loc, callee, args) {
-    return {
+  meta.codegenCall = function (loc, callee, args, verbatim) {
+    var node = {
       type: 'CallExpression',
       loc: loc,
       callee: callee,
       arguments: args
     };
+    if (typeof verbatim === 'string') {
+      node['x-verbatim'] = verbatim;
+    }
+    return node;
   };
   meta.codegenNew = function (loc, callee, args) {
     return {
@@ -1157,7 +1161,6 @@ function Meta() {
     // http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.2
     'unescape',
 
-    'eval',
     'Window',
     'console',
     'require',
@@ -1532,7 +1535,7 @@ function Meta() {
           parameters.push(args.codegenAsExpression(context));
         }
         var callee = expr.argAt(0).codegenAsExpression(context);
-        return meta.codegenCall(expr.loc, callee, parameters);
+        return meta.codegenCall(expr.loc, callee, parameters, expr.get('js'));
       }
     }));
   meta.addBuiltinKeySymbol(meta.callSymbol);
@@ -2554,10 +2557,12 @@ function Meta() {
     this.metaEnv.util = util;
 
     this.options = options || meta.copy(meta.Meta.options);
+    if (typeof this.options.escodegen === 'undefined') {
+      this.options.escodegen = {
+         verbatim: 'x-verbatim'
+      };
+    }
     if (typeof this.options.source !== 'undefined') {
-      if (typeof this.options.escodegen === 'undefined') {
-        this.options.escodegen = {};
-      }
       if (typeof this.options.map !== 'undefined') {
         this.options.escodegen.sourceMap = this.options.source;
         this.options.escodegen.sourceMapWithCode = true;

--- a/test/functional/js-macro.mjs
+++ b/test/functional/js-macro.mjs
@@ -1,0 +1,10 @@
+'''
+verbatim:30
+eval:40
+'''
+
+var foo = 10
+console.log( 'verbatim:' + js'foo + 20' )
+
+var code = 'foo + 30'
+console.log( 'eval:' + js code)


### PR DESCRIPTION
Some times it might be needed (or just helpful) to generate arbitrary javascript code. Right now we can use `eval` which gets the job done but it's too powerful and must be used with caution. This change enables verbatim output on escodegen and applies it only to calls for now, so that it's possible to annotate a call expression with some javascript code to be used at codegen.

There is also a simple macro `js` that serves as a safer replacement for `eval` (which is no longer a default external declaration). If the argument is a literal it will be used verbatim at codegen, otherwise it wraps the argument in a call to `eval` so that it can be resolved at runtime.

``` js
var foo = () =>
  assert this != js'this'
```

Note that when using `js` the developer is responsible for using it appropriately when including javascript statements, otherwise bad things can happen:

``` js
var foo = js'10; 20'  // `var foo = (10; 20)` which produces a javascript error
var foo = (#external eval) '10; 20'  // `var foo = eval('10; 20')` hence foo === 20
```

The principal use for this is to be able to optimize tight loops in an application if for whatever reason the metascript codegen introduces some unneeded overhead for that specific use case. Another important use case I'm playing with is how to handle runtime helper functions in macros, where this will provide an easy way to _embed_ supporting javascript code in the generated file.
