### PR TITLE
base for self-hosted compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 lib/core-macros.js*
 lib/regenerator-runtime.json
+lib/compiler/*.js*
 test/functional-test.js*
 test/meta-module.js*
 test/meta-test.js*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var argv = require('minimist')(process.argv.slice(2));
 // List of meta-script files to be compiled
 var files = {
   'compiler': [
-    'NOTHING YET'
+    './lib/compiler/*.mjs'
   ],
   'coremacros': [
     './lib/core-macros.mjs'
@@ -32,17 +32,18 @@ gulp.task('default', function (done) {
   return gulp.start('build');
 });
 
-gulp.task('coremacros', function () {
-  return gulp.src(files.coremacros)
+gulp.task('compiler', function () {
+  // Uses the bootstrapping compiler
+  return gulp.src(files.compiler)
   .pipe(cache('compiler'))
-  .pipe(exec('./bin/mjs -v --color --skip-core <%= file.path %>', execOpts))
+  .pipe(exec('./node_modules/.bin/mjs -v --color <%= file.path %>', execOpts))
   .pipe(exec.reporter())
 });
 
-gulp.task('compiler', function () {
-  return gulp.src(files.compiler)
+gulp.task('coremacros', ['compiler'], function () {
+  return gulp.src(files.coremacros)
   .pipe(cache('compiler'))
-  .pipe(exec('./bin/mjs -v --color <%= file.path %>', execOpts))
+  .pipe(exec('./bin/mjs -v --color --skip-core <%= file.path %>', execOpts))
   .pipe(exec.reporter())
 });
 

--- a/lib/compiler/constants.mjs
+++ b/lib/compiler/constants.mjs
@@ -1,0 +1,112 @@
+'''
+Enumerations of keywords and predefined symbols 
+'''
+
+#external exports
+
+; List of reserved JavaScript identifiers
+exports.RESERVED = [
+  'abstract'
+  'as'
+  'boolean'
+  'break'
+  'byte'
+  'case'
+  'catch'
+  'char'
+  'class'
+  'continue'
+  'const'
+  'debugger'
+  'default'
+  'delete'
+  'do'
+  'double'
+  'else'
+  'enum'
+  'export'
+  'extends'
+  'false'
+  'final'
+  'finally'
+  'float'
+  'for'
+  'function'
+  'goto'
+  'if'
+  'implements'
+  'import'
+  'in'
+  'instanceof'
+  'int'
+  'interface'
+  'is'
+  'long'
+  'namespace'
+  'native'
+  'new'
+  'null'
+  'package'
+  'private'
+  'protected'
+  'public'
+  'return'
+  'short'
+  'static'
+  'super'
+  'switch'
+  'synchronized'
+  'this'
+  'throw'
+  'throws'
+  'transient'
+  'true'
+  'try'
+  'typeof'
+  'use'
+  'var'
+  'void'
+  'volatile'
+  'while'
+  'with'
+  'yield'
+]
+
+; List of predefined external symbols in JavaScript
+; (just a joke for now, we need to have presets like jshint)
+; (eventually we will also parse typescript definitions)
+exports.PREDEFINED = [
+  'Object'
+  'String'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-8.5
+  'Number'
+  'Infinity'
+  ; https://github.com/joyent/node/wiki/ECMA-5-Mozilla-Features-Implemented-in-V8
+  'JSON'
+  'Boolean'
+  'Date'
+  'Array'
+  'Function'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-15.11.1
+  'Error'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.25
+  'parseInt'
+  'Math'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-15.10
+  'RegExp'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.1
+  'escape'
+  ; http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.2
+  'unescape'
+  
+  'window'
+  'console'
+  'require'
+
+  'this'
+  'NaN'
+  'true'
+  'false'
+  'undefined'
+  'null'
+]

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -17,6 +17,8 @@ function Meta() {
   var path = require('path');
   var escodegen = require('escodegen');
 
+  var constants = require('./compiler/constants');
+
 
   var debug = function () {
     console.log(util.format.apply(null, arguments));
@@ -1143,57 +1145,9 @@ function Meta() {
 
   // Root scope setup.
 
-  // External symbols.
-  // (just a joke for now, we need to have presets like jshint)
-  // (eventually we will also parse typescript definitions)
-  var predefined = [
-    'Object',
-    'String',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-8.5
-    'Number',
-    'Infinity',
-
-    // https://github.com/joyent/node/wiki/ECMA-5-Mozilla-Features-Implemented-in-V8
-    'JSON',
-    'Boolean',
-    'Date',
-    'Array',
-    'Function',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-15.11.1
-    'Error',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-4.3.25
-    'parseInt',
-    'Math',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-15.10
-    'RegExp',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.1
-    'escape',
-
-    // http://www.ecma-international.org/ecma-262/5.1/#sec-B.2.2
-    'unescape',
-
-    'Window',
-    'console',
-    'require',
-
-    'this',
-    'NaN',
-    'true',
-    'false',
-    'undefined',
-    'null'
-  ];
-  for (var predefined_index = 0;
-       predefined_index < predefined.length;
-       predefined_index++) {
-    var current_predefined = predefined[predefined_index];
-    meta.VAR_ROOT_SCOPE.set(current_predefined, meta.newReadonlyDeclaration(predefined));
-  }
+  constants.PREDEFINED.forEach(function (predefined) {
+    meta.VAR_ROOT_SCOPE.set(predefined, meta.newReadonlyDeclaration(predefined));
+  });
 
   meta.addBuiltinKeySymbol = function (symbol) {
     meta.KEY_ROOT_SCOPE.set(symbol.id, symbol);
@@ -2467,18 +2421,7 @@ function Meta() {
   meta.addBuiltinKeySymbol(meta.quoteSymbol);
 
 
-
-  meta.RESERVED.addAllKeysWithValue([
-    'abstract', 'as', 'boolean', 'break', 'byte', 'case', 'catch', 'char',
-    'class', 'continue', 'const', 'debugger', 'default', 'delete', 'do',
-    'double', 'else', 'enum', 'export', 'extends', 'false', 'final',
-    'finally', 'float', 'for', 'function', 'goto', 'if', 'implements',
-    'import', 'in', 'instanceof', 'int', 'interface', 'is', 'long',
-    'namespace', 'native', 'new', 'null', 'package', 'private', 'protected',
-    'public', 'return', 'short', 'static', 'super', 'switch', 'synchronized',
-    'this', 'throw', 'throws', 'transient', 'true', 'try', 'typeof', 'use',
-    'var', 'void', 'volatile', 'while', 'with', 'yield'
-  ]);
+  meta.RESERVED.addAllKeysWithValue(constants.RESERVED);
 
 
   meta.Error = function (message, line, column, originalLine, originalColumn, originalSource, nestedErrors) {
@@ -5877,9 +5820,11 @@ Object.defineProperty(Meta, 'VERSION', {
     return require('../package.json').version;
   }
 });
-Meta.prototype.version = function () {
-  return Meta.version;
-};
+Object.defineProperty(Meta.prototype, 'version', {
+  get: function () {
+    return Meta.VERSION;
+  }
+});
 
 Meta.prototype.clearOptions = function () {
   this.options = {};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "regenerator": "0.4.8"
   },
   "devDependencies": {
+    "meta-script": "// Use an older javascript-only version to bootstrap the compiler",
+    "meta-script": "=0.0.41",
     "gulp": "^3.8.1",
     "gulp-cached": "0.0.3",
     "gulp-exec": "^2.0.1",


### PR DESCRIPTION
![dogfood](http://www.mba.yuntech.edu.tw:8080/old_epaper/20120102/image/01-02.gif)

Paves the way to have a self hosted compiler. Any `.mjs` file in the `lib/compiler` directory will be compiled with a bootstrapping javascript only version of metascript (0.0.41 is included as a dev dependency).

This allows to start writing compiler components on metascript, for instance the incremental parser, which will surely help on finding bugs and awkwardnesses in the language itself.
