### PR TITLE
Allow tuples as rhs of member operator

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -1700,6 +1700,35 @@ function Meta() {
 
   meta.KEY_ROOT_SCOPE.set('.', new meta.Symbol('.', 'builtin',
     new meta.SymbolData(meta.arityBinary, 'MEMBER', {
+      fixTagKind: function (expr) {
+        // Convert tuples into chained member access (ie: fluent interfaces)
+        // console.log(expr.getSimpleValue(), expr.sym.id)
+        if (expr.at(1).isTuple()) {
+          var tuple = expr.at(1);
+          var lhs = expr.at(0);
+          while (tuple.count) {
+            var combined = tuple.at(0).newAtThisLocation('.');
+            combined.push(lhs);
+
+            lhs = tuple.shift();
+
+            // Find the left-most leave
+            var prop = lhs;
+            while (prop.count) {
+              prop = prop.at(0);
+            }
+
+            if (lhs !== prop) {
+              prop.replaceWith(combined);
+            } else {
+              lhs = combined;
+            }
+            combined.push(prop);
+          }
+          // Generate always a tuple so we support nesting the operator
+          expr.transformInto(lhs.asTuple());
+        }
+      },
       checkArity: function (expr) {
         expr.args[0].checkArity(1, -1, -1);
         if (expr.argAt(1).sym !== meta.nameSymbol) {

--- a/test/functional/tuple-member-access.mjs
+++ b/test/functional/tuple-member-access.mjs
@@ -1,0 +1,49 @@
+'''
+nested!
+qux
+3
+qux
+nested!
+'''
+
+var nested = {a: {b: {c: {d: {e: 'nested!' }}}}}
+var fluent = {
+  foo: () -> this
+  bar: () -> this
+  ; baz: o  ;; Node avoids creating circular references here
+  qux: 'qux'
+  nested: nested
+}
+fluent.baz = fluent  ;; But we can properly reference it outside
+
+console.log nested .
+  a
+  b
+  c
+  d
+  e
+
+console.log fluent .
+  qux
+
+console.log fluent .
+  qux
+  length
+
+console.log fluent .
+  foo()
+  bar.bind(fluent) 10
+  bar
+  bind(fluent) 20
+  baz
+  qux
+
+
+console.log fluent .
+  nested .
+    a
+    b
+    c
+    d
+    e
+


### PR DESCRIPTION
There is already the `|:` macro offering a similar mechanism, it seems to me however that this is frequently needed and makes sense to combine the standard member operator with the language support for tuples to make it more natural.
